### PR TITLE
Change shebang line to check bash path with env

### DIFF
--- a/letsencrypt-autorun
+++ b/letsencrypt-autorun
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ##
 ## letsencrypt-autorun
 ##

--- a/letsencrypt-generate
+++ b/letsencrypt-generate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ##
 ## letsencrypt-generate
 ##

--- a/letsencrypt-hash
+++ b/letsencrypt-hash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ##
 ## letsencrypt-hash
 ##

--- a/letsencrypt-install
+++ b/letsencrypt-install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ##
 ## letsencrypt-install
 ##

--- a/letsencrypt-renew
+++ b/letsencrypt-renew
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ##
 ## letsencrypt-renew
 ##

--- a/letsencrypt-request
+++ b/letsencrypt-request
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ##
 ## letsencrypt-request
 ##

--- a/letsencrypt-tlsa
+++ b/letsencrypt-tlsa
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ##
 ## letsencrypt-tlsa
 ##


### PR DESCRIPTION
Since I use your scripts on FreeBSD with Bash installed, my main worry was the script not being able to run due to the differing binary paths. I made changes to the shebang line to check the shell binary path with `env` to make the scripts more cross-compatible with different distros and even with BSD systems.